### PR TITLE
Chore: Rename module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "birddog-visca",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Protocol",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
-	"name": "birddog-visca",
+	"name": "birddog-ptz",
+	"legacy": [
+		"birddog-visca"
+	],
 	"version": "2.0.1",
 	"api_version": "1.0.0",
 	"keywords": [
@@ -16,16 +19,17 @@
 	},
 	"author": "Benni M. <info@benni-m.de>",
 	"contributors": [
-		"Bryce Seifert"
+		"Bryce Seifert",
+		"Jamie McC"
 	],
 	"license": "MIT",
-	"homepage": "https://github.com/bitfocus/companion-module-birddog-visca#readme",
+	"homepage": "https://github.com/bitfocus/companion-module-birddog-ptz#readme",
 	"bugs": {
-		"url": "https://github.com/bitfocus/companion-module-birddog-visca/issues"
+		"url": "https://github.com/bitfocus/companion-module-birddog-ptz/issues"
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/bitfocus/companion-module-birddog-visca.git"
+		"url": "git+https://github.com/bitfocus/companion-module-birddog-ptz.git"
 	},
 	"dependencies": {
 		"node-fetch": "^2.6.7"


### PR DESCRIPTION
Change module name since it now uses both the API and VISCA for communication